### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In your composer.json add the following dependency:
 
 ```json
 "require": {
-        "videlalvaro/azserverless": "*"
+        "videlalvaro/azserverless": "dev-main"
 }
 ```
 


### PR DESCRIPTION
Updating README.md to avoid ` Root composer.json requires videlalvaro/azserverless *, found videlalvaro/azserverless[dev-main] but it does not match your minimum-stability` error message.